### PR TITLE
added a at_exit hook to close the file and added some tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,2 +1,9 @@
 = 0.1.0: 12-Dec-2010
 * Initial release
+
+= 0.1.1: 15-Dec-2010
+* defined a at_exit hook to close the file locked only if the DATA constant was not provided. 
+  otherwise it is the responsibility of the developer 
+* calling exit not exit! so that the at_exit handlers are called
+* non-zero return status denotes error-condition
+* added unit-test to check that locking and at_exit handlers work. it has some warts. check the TODO in the test file

--- a/lib/highlander.rb
+++ b/lib/highlander.rb
@@ -1,19 +1,27 @@
 module Highlander
   # The version of the highlander library
-  VERSION = '0.1.0'
-
+  VERSION = '0.1.1'
+  
   BEGIN{
     unless $0 == 'irb'
       program = File.expand_path($0)
-      DATA = File.open(program) unless defined?(DATA)
+      unless defined?(DATA)
+        DATA = File.open(program)
+        at_exit { highlander_at_exit }
+      end
       status = DATA.flock(File::LOCK_EX | File::LOCK_NB)
 
       if status != 0
         raise RuntimeError, "Program '#{program}' already running"
-        exit! # In case of rescue, forcibly bail
+        exit 1 # In case of error, bail out
       end
     end
   }
+
+  # you can override this function at the toplevel or Highlander#highlander_at_exit
+  def highlander_at_exit
+    DATA.close if Object.const_defined?(:DATA) && DATA.respond_to?(:close)
+  end
 end
 
 include Highlander

--- a/test/locking_runner.rb
+++ b/test/locking_runner.rb
@@ -1,0 +1,18 @@
+require 'optparse'
+require 'highlander.rb'
+
+def highlander_at_exit
+  super
+  `touch /tmp/highlander_at_exit.txt`
+end
+
+sec = nil
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{__FILE__} [options]"
+
+  opts.on("-s", "--sleep sec", Integer, "seconds to sleep ") do |f|
+    sec = f
+  end
+end.parse!
+
+sleep sec if sec

--- a/test/test_highlander.rb
+++ b/test/test_highlander.rb
@@ -3,10 +3,15 @@
 #
 # Test suite for the highlander gem.
 #######################################################################
+
+# usage: ruby -I lib/ -I test/ test/test_highlander.rb
 require 'test/unit'
 require 'highlander'
+require 'testing_helper.rb'
 
 class TC_Highlander < Test::Unit::TestCase
+  include TestingHelper
+  
   def setup
   end
 
@@ -14,6 +19,31 @@ class TC_Highlander < Test::Unit::TestCase
     assert_equal("0.1.0", Highlander::VERSION)
   end
 
-  def teardown
+  def test_at_exit
+    delete_flag_file
+    call_locking_runner
+    assert_equal(true, File.exists?(FLAG_FILE))
+    delete_flag_file
+  end
+  
+  def test_locking
+    locked = fork do
+      exec("ruby -I #{LIB} #{RUNNER} --sleep 1000")
+    end
+    # at this point `ps -aux | grep locking_runner` will be running
+    # also lsof <filename> will have W in the fd ie.file-descriptor column
+    Process.detach(locked)
+
+    # WTF!!!
+    # TODO: need this due to some reason otherwise the exitstatus is zero
+    # and the 'locked' process forked above is not killed.
+    sleep 5
+
+    # TODO: suppress the error output
+    call_locking_runner
+    assert_equal(1, $?.exitstatus)
+
+    #cleanup
+    Process.kill("HUP", locked)
   end
 end

--- a/test/testing_helper.rb
+++ b/test/testing_helper.rb
@@ -1,0 +1,17 @@
+module TestingHelper
+  FLAG_FILE = '/tmp/highlander_at_exit.txt'
+  LIB = File.expand_path('../../lib', __FILE__)
+  RUNNER = File.expand_path('../locking_runner.rb', __FILE__)
+  
+  def delete_flag_file
+    begin
+      File.delete(FLAG_FILE)
+    rescue Errno::ENOENT
+      #noop
+    end
+  end
+
+  def call_locking_runner
+    `ruby -I #{LIB} #{RUNNER}`
+  end
+end


### PR DESCRIPTION
- defined a at_exit hook to close the file locked only if the DATA constant was not provided. 
  otherwise it is the responsibility of the developer 
- calling exit not exit! so that the at_exit handlers are called
- non-zero return status denotes error-condition
- added unit-test to check that locking and at_exit handlers work. it has some warts. check the TODO in the test file
